### PR TITLE
UR-2082 - adding scrollPage method to Onboarding Component

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- `components/Onboarding` - added `updateParentIndex` and `scrollPage` to allow different CTA Button Handlers (UR-2082)
+
 ## [0.3.4 - 2020-09-01]
 
 ### Added

--- a/showcase/screens/Onboarding2.tsx
+++ b/showcase/screens/Onboarding2.tsx
@@ -52,7 +52,6 @@ class Onboarding extends React.PureComponent<OnboardingProps, OnboardingScreenSt
 
   updateIndex(index: number) {
     this.setState({ index });
-    console.log('this.state.index', this.state.index);
   }
 
   render() {

--- a/showcase/screens/Onboarding2.tsx
+++ b/showcase/screens/Onboarding2.tsx
@@ -45,9 +45,12 @@ class Onboarding extends React.PureComponent<OnboardingProps, OnboardingScreenSt
   next() {
     const { index } = this.state;
     const endReached = index === pages.length - 1;
-    this.onboardingComponent?.current?.scrollToPage(index + 2);
-    this.setState({ index: index + 1 });
-    if (endReached) this.props.navigation.navigate('Onboarding (single page)');
+    if (endReached) {
+      this.props.navigation.navigate('Onboarding (single page)');
+    } else {
+      this.onboardingComponent?.current?.scrollToPage(index + 2);
+      this.setState({ index: index + 1 });
+    }
   }
 
   updateIndex(index: number) {

--- a/showcase/screens/Onboarding2.tsx
+++ b/showcase/screens/Onboarding2.tsx
@@ -62,7 +62,7 @@ class Onboarding extends React.PureComponent<OnboardingProps, OnboardingScreenSt
       <OnboardingComponent
         ref={this.onboardingComponent}
         cta={{
-          label: endReached ? 'close' : 'check last',
+          label: endReached ? 'close' : 'check next',
           onPress: () => this.next(),
         }}
         pages={pages}

--- a/showcase/screens/Onboarding2.tsx
+++ b/showcase/screens/Onboarding2.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import { Onboarding as OnboardingComponent } from 'react-native-urbi-ui/components/Onboarding';
 import { OnboardingProps } from './Onboarding';
 import { onIphoneX } from '../utils/const';
@@ -16,18 +16,58 @@ const pages = [
       'You did it! Great job at swiping that page!\nNow, try clicking on the CTA to see yet another example of an onboarding component.\nAlso, did you see how images up there take the whole width of your device, while dynamically being resized according to their height? Yes? Gr8!',
     image: require('../assets/onboarding.png'),
   },
+  {
+    title: "Look at me, I'm a title spanning two lines. Spiffy, uh?",
+    content:
+      "Oh hai! I'm a 2-page onboarding component. Try swiping to the next page, see what happens.",
+    image: require('../assets/onboarding2.png'),
+  },
+  {
+    title: 'title label',
+    content:
+      'You did it! Great job at swiping that page!\nNow, try clicking on the CTA to see yet another example of an onboarding component.\nAlso, did you see how images up there take the whole width of your device, while dynamically being resized according to their height? Yes? Gr8!',
+    image: require('../assets/onboarding.png'),
+  },
 ];
 
-class Onboarding extends React.PureComponent<OnboardingProps> {
+type OnboardingScreenState = {
+  index: number;
+};
+
+class Onboarding extends React.PureComponent<OnboardingProps, OnboardingScreenState> {
+  private onboardingComponent = createRef<OnboardingComponent>();
+  constructor(props: OnboardingProps) {
+    super(props);
+    this.state = { index: 0 };
+    this.onboardingComponent = createRef();
+  }
+
+  next() {
+    const { index } = this.state;
+    const endReached = index === pages.length - 1;
+    this.onboardingComponent?.current?.scrollPage(1, index + 2);
+    this.setState({ index: index + 1 });
+    if (endReached) this.props.navigation.navigate('Onboarding (single page)');
+  }
+
+  updateIndex(index: number) {
+    this.setState({ index });
+    console.log('this.state.index', this.state.index);
+  }
+
   render() {
+    const { index } = this.state;
+    const endReached = index === pages.length - 1;
     return (
       <OnboardingComponent
+        ref={this.onboardingComponent}
         cta={{
-          label: 'check last',
-          onPress: () => this.props.navigation.navigate('Onboarding (single page)'),
+          label: endReached ? 'close' : 'check last',
+          onPress: () => this.next(),
         }}
         pages={pages}
         onIphoneX={onIphoneX}
+        updateParentIndex={(index: number) => this.updateIndex(index)}
       />
     );
   }

--- a/showcase/screens/Onboarding2.tsx
+++ b/showcase/screens/Onboarding2.tsx
@@ -45,7 +45,7 @@ class Onboarding extends React.PureComponent<OnboardingProps, OnboardingScreenSt
   next() {
     const { index } = this.state;
     const endReached = index === pages.length - 1;
-    this.onboardingComponent?.current?.scrollPage(1, index + 2);
+    this.onboardingComponent?.current?.scrollToPage(index + 2);
     this.setState({ index: index + 1 });
     if (endReached) this.props.navigation.navigate('Onboarding (single page)');
   }

--- a/showcase/screens/Onboarding2.tsx
+++ b/showcase/screens/Onboarding2.tsx
@@ -48,8 +48,9 @@ class Onboarding extends React.PureComponent<OnboardingProps, OnboardingScreenSt
     if (endReached) {
       this.props.navigation.navigate('Onboarding (single page)');
     } else {
-      this.onboardingComponent?.current?.scrollToPage(index + 2);
-      this.setState({ index: index + 1 });
+      const newIndex = index + 1;
+      this.setState({ index: newIndex });
+      this.onboardingComponent?.current?.scrollToPage(newIndex);
     }
   }
 

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -84,8 +84,6 @@ type OnboardingState = {
   pageWidth: number;
 };
 
-type ScrollDirection = 1 | -1;
-
 export const renderOnboardingPage = (
   page: OnboardingPage,
   index: number,
@@ -131,9 +129,9 @@ export class Onboarding extends React.PureComponent<OnboardingProps, OnboardingS
     this.props.updateParentIndex?.(newPageIndex);
   }
 
-  scrollPage(direction: ScrollDirection, index: number) {
+  scrollToPage(index: number) {
     const { pageWidth } = this.state;
-    this.scrollViewRef.current.scrollTo({ x: direction * index * pageWidth });
+    this.scrollViewRef.current.scrollTo({ x: index * pageWidth });
     this.setState({ currentPageIndex: index - 1 });
   }
 

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -132,7 +132,7 @@ export class Onboarding extends React.PureComponent<OnboardingProps, OnboardingS
   scrollToPage(index: number) {
     const { pageWidth } = this.state;
     this.scrollViewRef.current.scrollTo({ x: index * pageWidth });
-    this.setState({ currentPageIndex: index - 1 });
+    this.setState({ currentPageIndex: index });
   }
 
   render() {

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -76,6 +76,7 @@ type OnboardingProps = {
   titleStyle?: TextStyle;
   contentStyle?: TextStyle;
   titleLowercase?: boolean;
+  updateParentIndex?: (index: number) => void;
 };
 
 type OnboardingState = {
@@ -125,12 +126,15 @@ export class Onboarding extends React.PureComponent<OnboardingProps, OnboardingS
 
   onScrollEnd(e: NativeSyntheticEvent<NativeScrollEvent>) {
     const offset = e.nativeEvent.contentOffset.x;
-    this.setState({ currentPageIndex: Math.floor(offset / this.state.pageWidth) });
+    const newPageIndex = Math.floor(offset / this.state.pageWidth);
+    this.setState({ currentPageIndex: newPageIndex });
+    this.props.updateParentIndex?.(newPageIndex);
   }
 
   scrollPage(direction: ScrollDirection, index: number) {
     const { pageWidth } = this.state;
-    this.scrollViewRef.current.scrollTo({ x: index * pageWidth });
+    this.scrollViewRef.current.scrollTo({ x: direction * index * pageWidth });
+    this.setState({ currentPageIndex: index - 1 });
   }
 
   render() {

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import {
   Dimensions,
   Image,
@@ -83,6 +83,8 @@ type OnboardingState = {
   pageWidth: number;
 };
 
+type ScrollDirection = 1 | -1;
+
 export const renderOnboardingPage = (
   page: OnboardingPage,
   index: number,
@@ -108,11 +110,13 @@ export const renderOnboardingPage = (
 };
 
 export class Onboarding extends React.PureComponent<OnboardingProps, OnboardingState> {
+  private scrollViewRef = createRef<ScrollView>();
   constructor(props: OnboardingProps) {
     super(props);
     this.state = { currentPageIndex: 0, pageWidth: Dimensions.get('window').width };
     this.onLayout = this.onLayout.bind(this);
     this.onScrollEnd = this.onScrollEnd.bind(this);
+    this.scrollViewRef = createRef();
   }
 
   onLayout(e: LayoutChangeEvent) {
@@ -124,6 +128,11 @@ export class Onboarding extends React.PureComponent<OnboardingProps, OnboardingS
     this.setState({ currentPageIndex: Math.floor(offset / this.state.pageWidth) });
   }
 
+  scrollPage(direction: ScrollDirection, index: number) {
+    const { pageWidth } = this.state;
+    this.scrollViewRef.current.scrollTo({ x: index * pageWidth });
+  }
+
   render() {
     const { cta, onIphoneX, pages, titleLowercase } = this.props;
     const { currentPageIndex, pageWidth } = this.state;
@@ -133,6 +142,7 @@ export class Onboarding extends React.PureComponent<OnboardingProps, OnboardingS
       <View style={styles.Wrapper}>
         {pages.length > 1 ? (
           <ScrollView
+            ref={this.scrollViewRef}
             style={styles.Wrapper}
             onLayout={this.onLayout}
             onMomentumScrollEnd={this.onScrollEnd}


### PR DESCRIPTION
https://github.com/urbi-mobility/urbi-react-native/pull/154
https://urbimobility.atlassian.net/browse/UR-2082

The scrollTo method is necessary to use the button to go to the next page in ScrollView

1) A ref from the ScrollView node/instance is saved in instance variable this.scrollViewRef
2) scrollPage method is exposes using this.scrollViewRef.current.scrollTo https://github.com/urbi-mobility/react-native-urbi-ui/pull/16/commits/09e87cfdefe7201cbcec0b41e39b68bf6262200d
https://reactnative.dev/docs/scrollview#scrollto
3) scrollPage updates the internal component state this.state.currentPageIndex https://github.com/urbi-mobility/react-native-urbi-ui/pull/16/commits/09e87cfdefe7201cbcec0b41e39b68bf6262200d
4) the state will change the PageIndicator https://github.com/urbi-mobility/react-native-urbi-ui/pull/16/commits/09e87cfdefe7201cbcec0b41e39b68bf6262200d
5) onScrollEnd callback updateParentIndex?.(newPageIndex) updates the parent state (for changing the pageIndex with scroll gestures) https://github.com/urbi-mobility/react-native-urbi-ui/pull/16/commits/09e87cfdefe7201cbcec0b41e39b68bf6262200d

The below example is included in commit https://github.com/urbi-mobility/react-native-urbi-ui/pull/16/commits/ecb5558536503a869444d090094d6f24507b7002
This pr is in draft as I need to integrate/text the functionality with pr https://github.com/urbi-mobility/urbi-react-native/pull/154

| **ShowCase app** | **dev Onboarding** | 
|:-------------------------:|:-------------------------:|
|  <img src="https://user-images.githubusercontent.com/24992535/91943763-62ff4900-ecfd-11ea-9780-0b3b63e2b0ee.gif"  width="300" height="" />| <img src="https://user-images.githubusercontent.com/24992535/91983356-d750e100-ed2b-11ea-81b0-b21ad9462e7d.gif" width="300" height="" /> |

