### PR TITLE
adding status panel test id

### DIFF
--- a/src/components/StatusPanel.tsx
+++ b/src/components/StatusPanel.tsx
@@ -112,7 +112,12 @@ export class StatusPanel extends React.PureComponent<StatusPanelProps, StatusPan
             horizontal
           >
             {this.props.pages.map((s, i) => (
-              <Touchable key={i} style={styles.Touchable} onPress={this.props.onPress}>
+              <Touchable
+                testID="statusPanelTestID"
+                key={i}
+                style={styles.Touchable}
+                onPress={this.props.onPress}
+              >
                 <Status key={`page-${i}`} {...s} minWidth={this.state.scrollViewWidth} />
               </Touchable>
             ))}


### PR DESCRIPTION
MapScreen Tests are being rewritten with pr https://github.com/urbi-mobility/urbi-react-native/pull/290 
Related PR that needs update for react-native-urbi-ui package is https://github.com/urbi-mobility/urbi-react-native/pull/301

- The kickscooter rental end to end test is replaced with 3 separate
  tests that test different states in the application, instead of
  triggering next state and verifying that the state changes like a e2e
  test.
- 1st test will render not rented kickscooter and then unlock it
https://github.com/urbi-mobility/urbi-react-native/pull/303/commits/368cf05ccbf864782c271e86e0697c3021f03786
- 2nd test will select an already rented kickscooter by clicking in the
  testID added with this commit and then verify all information are
  displayed correctly
https://github.com/urbi-mobility/urbi-react-native/pull/303/commits/27a8310e838fa17bf6e50e8233aec90f2f6f2d8c
- 3rd test will end the rental and display the price