### PR TITLE
Detox - fix test failures caused by testIDs

### DIFF
--- a/src/components/FilterGroup.tsx
+++ b/src/components/FilterGroup.tsx
@@ -36,7 +36,6 @@ const buttons = (props: FilterGroupProps) =>
       setActive={props.onFilterToggle}
       managed={props.managed}
       loading={b.loading}
-      testID={`${props.testID ?? 'filterGroupToggle'}-${b.id}`}
     />
   ));
 
@@ -56,7 +55,6 @@ const FilterGroupUnmemoized = (props: FilterGroupProps) => {
           buttonStyle={props.lastButton.active ? 'brand' : 'primary'}
           icon={props.lastButton.icon}
           onPress={props.lastButton.onPress}
-          testID={`${props.testID ?? 'filterGroupToggle'}-last`}
         />
       ) : null}
     </View>

--- a/src/molecules/buttons/iconButtons/IconButton.android.tsx
+++ b/src/molecules/buttons/iconButtons/IconButton.android.tsx
@@ -73,7 +73,7 @@ export class IconButton extends React.PureComponent<IconButtonExtendedProps> {
         elevation={backgroundColor === colors.transparent || disabled || noShadow ? 0 : 1}
       >
         <TouchableNativeFeedback
-          testID={testID ?? `${icon}IconButtonTestID`}
+          testID={testID || `${icon}IconButtonTestID`}
           onLongPress={disabled ? undefined : onLongPress}
           onPress={disabled ? undefined : onPress}
           onPressIn={disabled ? undefined : onPressIn}

--- a/src/molecules/buttons/iconButtons/IconButton.ios.tsx
+++ b/src/molecules/buttons/iconButtons/IconButton.ios.tsx
@@ -77,7 +77,7 @@ export class IconButton extends React.PureComponent<IconButtonExtendedProps> {
 
     return (
       <TouchableOpacity
-        testID={testID ?? `${icon}IconButtonTestID`}
+        testID={testID || `${icon}IconButtonTestID`}
         onLongPress={disabled ? undefined : onLongPress}
         onPress={disabled ? undefined : onPress}
         onPressIn={disabled ? undefined : onPressIn}


### PR DESCRIPTION
- ?? changed to || to avoid using testID "" or 0
- removed testID from filterGroup, overwrites testID IconButton.android
  "kickscooterIconButtonTestID"